### PR TITLE
Add site scaffolding and CI

### DIFF
--- a/.github/workflows/html-verify.yml
+++ b/.github/workflows/html-verify.yml
@@ -1,0 +1,13 @@
+name: HTML verify
+on:
+  push:
+  pull_request:
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.x' }
+      - run: pip install html5validator
+      - run: html5validator --root . --also-check-css --blacklist ".git,.github"

--- a/404.html
+++ b/404.html
@@ -1,0 +1,6 @@
+<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8">
+<meta http-equiv="refresh" content="0; url=/">
+<title>404 — Not Found</title>
+</head><body>404</body></html>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# nogaslabs-site
+# No_Gas_Labs — Official Shrine
+
+Static site for press releases, relics, and campaign info.
+
+## Develop locally
+```bash
+python3 -m http.server 8080
+# open http://localhost:8080
+```
+
+Structure
+
+index.html, about.html
+
+press/, relics/, campaign/
+
+site.css, site.js
+
+.nojekyll, 404.html
+
+Deploy
+
+Enable GitHub Pages: Settings → Pages → Source: main / root.
+Site: https://no-gas-labs.github.io/nogaslabs-site/.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,6 @@
+# Roadmap
+- Press 001–010: publish cadence and archive
+- Relics: add live demos, screenshots
+- Accessibility pass: color contrast + keyboard nav
+- Analytics (privacy-light) and link check script
+- Custom domain mapping (nogaslabs.com)

--- a/about.html
+++ b/about.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>About — No_Gas_Labs</title>
+<link rel="stylesheet" href="site.css">
+</head><body>
+<header class="wrap"><nav class="nav">
+  <a href="./">Home</a><a href="./about.html">About</a>
+  <a href="./press/">Press</a><a href="./relics/">Relics</a><a href="./campaign/">Campaign</a>
+</nav></header>
+<main class="wrap">
+  <h1>About No_Gas_Labs</h1>
+  <p>No_Gas_Labs is Damien Edward Featherstone’s public lab: releases, prototypes, and the campaign in plain sight.</p>
+  <h2>Purpose</h2><p>Ship clear ideas, measure impact, keep receipts.</p>
+  <h2>Contact</h2><p><a href="mailto:press@nogaslabs.com">press@nogaslabs.com</a></p>
+</main>
+<footer class="wrap foot">Paid for by Damien Edward Featherstone for President (2028).</footer>
+</body></html>

--- a/campaign/index.html
+++ b/campaign/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Campaign — No_Gas_Labs</title>
+<link rel="stylesheet" href="../site.css">
+<p>Campaign details will go here.</p>

--- a/index.html
+++ b/index.html
@@ -1,1 +1,36 @@
+<!doctype html>
+<html lang="en"><head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>No_Gas_Labs — Official Shrine</title>
+  <link rel="stylesheet" href="site.css">
+  <meta name="description" content="Official site for Damien Edward Featherstone — press releases, relics, campaign.">
+</head><body>
+  <header class="wrap">
+    <nav class="nav">
+      <a href="./">Home</a>
+      <a href="./about.html">About</a>
+      <a href="./press/">Press</a>
+      <a href="./relics/">Relics</a>
+      <a href="./campaign/">Campaign</a>
+    </nav>
+  </header>
 
+  <main class="wrap">
+    <h1>🌀 No_Gas_Labs — Official Shrine</h1>
+    <p>Plain-language hub for releases, relics, and the campaign.</p>
+    <p class="cta"><a href="./press/">Read Press Releases</a></p>
+
+    <section class="grid">
+      <div class="card"><h2>XP Counter</h2><p>Session XP: <strong id="xp">0</strong></p></div>
+      <div class="card"><h2>Relics</h2><p><a href="./relics/">Browse relics</a></p></div>
+      <div class="card"><h2>Campaign</h2><p><a href="./campaign/">Get the plan</a></p></div>
+    </section>
+  </main>
+
+  <footer class="wrap foot">
+    <div>Contact: <a href="mailto:press@nogaslabs.com">press@nogaslabs.com</a></div>
+    <div>Paid for by Damien Edward Featherstone for President (2028).</div>
+  </footer>
+  <script src="site.js"></script>
+</body></html>

--- a/press/index.html
+++ b/press/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Press — No_Gas_Labs</title>
+<link rel="stylesheet" href="../site.css">
+<p>Press releases coming soon.</p>

--- a/relics/index.html
+++ b/relics/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Relics — No_Gas_Labs</title>
+<link rel="stylesheet" href="../site.css">
+<p>Relics will be listed here soon.</p>

--- a/site.css
+++ b/site.css
@@ -1,0 +1,9 @@
+:root{--bg:#0f0f10;--fg:#f2f2f2;--muted:#bdbdbd;--line:#232323;--accent:#62d0ff}
+*{box-sizing:border-box}html,body{margin:0;background:var(--bg);color:var(--fg);font:16px/1.5 ui-monospace,Menlo,Consolas,monospace}
+a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}
+.wrap{max-width:960px;margin:0 auto;padding:18px}
+.nav{display:flex;gap:14px;padding:10px 0;border-bottom:1px solid var(--line)}
+.grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));margin-top:16px}
+.card{border:1px solid var(--line);border-radius:10px;padding:14px;background:#141417}
+.foot{margin-top:36px;border-top:1px solid var(--line);color:var(--muted)}
+.cta a{display:inline-block;border:1px solid var(--line);padding:8px 12px;border-radius:8px}

--- a/site.js
+++ b/site.js
@@ -1,0 +1,6 @@
+(function(){
+  const el=document.querySelector("#xp"); if(!el) return;
+  const k="ngl_xp"; let xp=parseInt(localStorage.getItem(k)||"0",10);
+  const bump=()=>{ xp+=1; localStorage.setItem(k,String(xp)); el.textContent=xp; };
+  bump(); setInterval(bump,5000);
+})();


### PR DESCRIPTION
## Summary
- scaffold landing page and navigation
- add About page
- add CSS and JS
- set up stub pages
- document local development and roadmap
- add basic HTML validation workflow

## Testing
- `pip install html5validator`
- `html5validator --root . --also-check-css --blacklist ".git,.github"`

------
https://chatgpt.com/codex/tasks/task_e_6888681fc4008322ae6da58dcd452695