### PR TITLE
Follow-Up Sprint #3 updates

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,3 @@
+Contact: mailto:press@nogaslabs.com
+Preferred-Languages: en
+Policy: https://no-gas-labs.github.io/nogaslabs-site/

--- a/404.html
+++ b/404.html
@@ -1,6 +1,10 @@
 <!doctype html>
 <html lang="en"><head>
 <meta charset="utf-8">
-<meta http-equiv="refresh" content="0; url=/">
 <title>404 — Not Found</title>
-</head><body>404</body></html>
+<style>body{font-family:ui-monospace,monospace;background:#0f0f10;color:#f2f2f2;margin:0;padding:40px}a{color:#62d0ff}</style>
+</head><body>
+<h1>404 — Not Found</h1>
+<p>The page you requested could not be found.</p>
+<p><a href="/nogaslabs-site/">Home</a> | <a href="/nogaslabs-site/press/">Press</a></p>
+</body></html>

--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ Site map
 - Relics
 - Campaign
 - Press Kit
+- [RSS Feed](https://no-gas-labs.github.io/nogaslabs-site/press/feed.xml)
+- [Press Kit](https://no-gas-labs.github.io/nogaslabs-site/press/kit.html)
+
+Scripts
+- `scripts/new-press.sh` helps create and index new press releases.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,3 +7,6 @@
 - Accessibility pass (contrast tokens + keyboard check)
 - RSS feed for Press (/press/feed.xml)
 - Press Kit assets (headshot, vector logo)
+- Add OG image generator (SVG to PNG fallback).
+- Keyboard-only pass on Press pages.
+- Press 002 draft + schedule.

--- a/assets/headshot.svg
+++ b/assets/headshot.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <rect width="200" height="200" fill="#62d0ff"/>
+  <text x="50" y="120" font-size="80" font-family="sans-serif" fill="#0f0f10">DEF</text>
+</svg>

--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <circle cx="100" cy="100" r="80" fill="#62d0ff"/>
+</svg>

--- a/assets/wordmark.svg
+++ b/assets/wordmark.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 80">
+  <text x="10" y="55" font-size="50" font-family="sans-serif" fill="#f2f2f2">No_Gas_Labs</text>
+</svg>

--- a/humans.txt
+++ b/humans.txt
@@ -1,0 +1,3 @@
+/* TEAM */
+Author: Damien Edward Featherstone
+Site: No_Gas_Labs

--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
   <meta name="viewport" content="width=device-width,initial-scale=1"/>
   <title>No_Gas_Labs — Official Shrine</title>
   <link rel="stylesheet" href="site.css">
+  <link rel="alternate" type="application/rss+xml" href="/press/feed.xml" title="No_Gas_Labs Press">
+  <link rel="canonical" href="https://no-gas-labs.github.io/nogaslabs-site/">
+  <meta name="robots" content="index,follow">
+  <link rel="manifest" href="/manifest.webmanifest">
   <meta name="description" content="Official site for Damien Edward Featherstone — press releases, relics, campaign.">
   <link rel="icon" href="assets/favicon.svg">
   <meta property="og:title" content="No_Gas_Labs — Official Shrine">

--- a/manifest.webmanifest
+++ b/manifest.webmanifest
@@ -1,0 +1,4 @@
+{ "name":"No_Gas_Labs", "short_name":"NGL",
+  "start_url":"/nogaslabs-site/", "display":"standalone",
+  "background_color":"#0f0f10", "theme_color":"#0f0f10",
+  "icons":[{ "src":"/nogaslabs-site/assets/favicon.svg", "sizes":"64x64", "type":"image/svg+xml" }] }

--- a/press/_TEMPLATE.tpl
+++ b/press/_TEMPLATE.tpl
@@ -1,10 +1,10 @@
 <!doctype html>
 <html lang="en"><head>
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
-<title>Press 001 - Mirror's Edge</title>
+<title>{{TITLE}}</title>
 <link rel="stylesheet" href="../site.css">
 <link rel="alternate" type="application/rss+xml" href="/press/feed.xml" title="No_Gas_Labs Press">
-<link rel="canonical" href="https://no-gas-labs.github.io/nogaslabs-site/press/001-mirrors-edge.html">
+<link rel="canonical" href="{{CANONICAL}}">
 <meta name="robots" content="index,follow">
 </head><body>
 <header class="wrap"><nav class="nav">
@@ -12,12 +12,11 @@
   <a href="../press/">Press</a><a href="../relics/">Relics</a><a href="../campaign/">Campaign</a>
 </nav></header>
 <main class="wrap">
-  <h1>Mirror's Edge</h1>
-  <p><strong>Date:</strong> Jul 28, 2025</p>
+  <h1>{{HEADLINE}}</h1>
+  <p><strong>Date:</strong> {{DATE}}</p>
   <p><strong>From:</strong> Damien Edward Featherstone</p>
   <p><strong>Contact:</strong> <a href="mailto:press@nogaslabs.com">press@nogaslabs.com</a></p>
-  <p>This first release outlines the vision for No_Gas_Labs. We are rebuilding systems that fail everyday people.</p>
-  <p>Our approach is simple: publish the fix, test in public, ship what works.</p>
+  {{BODY}}
 </main>
 <footer class="wrap foot">Paid for by Damien Edward Featherstone for President (2028).</footer>
 </body></html>

--- a/press/index.html
+++ b/press/index.html
@@ -3,6 +3,9 @@
 <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>Press — No_Gas_Labs</title>
 <link rel="stylesheet" href="../site.css">
+<link rel="alternate" type="application/rss+xml" href="/press/feed.xml" title="No_Gas_Labs Press">
+<link rel="canonical" href="https://no-gas-labs.github.io/nogaslabs-site/press/">
+<meta name="robots" content="index,follow">
 </head><body>
 <header class="wrap"><nav class="nav">
   <a href="../">Home</a><a href="../about.html">About</a>

--- a/press/kit.html
+++ b/press/kit.html
@@ -14,9 +14,16 @@
   <p>He works from first principles and ships tools that put people first.</p>
   <p>For interviews or more information, use the contact below.</p>
   <h2>Headshot</h2>
-  <p><a href="../assets/headshot.jpg">Download headshot</a></p>
+  <p><a href="../assets/headshot.svg">Download headshot</a></p>
   <h2>Logos</h2>
   <p><img src="../assets/favicon.svg" alt="Logo" width="48" height="48"></p>
+  <h2>Assets</h2>
+  <ul>
+    <li><a href="../assets/logo.svg">Logo (SVG)</a></li>
+    <li><a href="../assets/wordmark.svg">Wordmark (SVG)</a></li>
+    <li><a href="../assets/headshot.svg">Headshot (SVG)</a></li>
+  </ul>
+  <p>Use these graphics for press coverage.</p>
   <p><a href="./">Back to Press</a> | <a href="../">Home</a></p>
 </main>
 <footer class="wrap foot">Paid for by Damien Edward Featherstone for President (2028).</footer>

--- a/scripts/new-press.sh
+++ b/scripts/new-press.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# usage: new-press.sh N slug
+set -e
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 N slug" >&2
+  exit 1
+fi
+N="$1"
+SLUG="$2"
+FILE="press/${N}-${SLUG}.html"
+if [ -f "$FILE" ]; then
+  echo "$FILE exists"
+  exit 0
+fi
+DATE=$(date +"%b %d, %Y")
+HEAD=$(printf '%s' "$SLUG" | tr '-' ' ' | sed 's/^./\u&/')
+TITLE="Press $N - $HEAD"
+CANON="https://no-gas-labs.github.io/nogaslabs-site/press/${N}-${SLUG}.html"
+sed -e "s/{{TITLE}}/$TITLE/" \
+    -e "s/{{HEADLINE}}/$HEAD/" \
+    -e "s/{{DATE}}/$DATE/" \
+    -e "s|{{CANONICAL}}|$CANON|" \
+    -e "s/{{BODY}}/<p>New press release.<\/p>/" \
+    press/_TEMPLATE.tpl > "$FILE"
+# update index
+LINE="    <li><a href=\"./${N}-${SLUG}.html\">${N} - ${HEAD} (${DATE})</a></li>"
+if ! grep -q "${N}-${SLUG}.html" press/index.html; then
+  sed -i "/<ul>/a\
+$LINE" press/index.html
+fi
+# update feed
+if ! grep -q "${N}-${SLUG}.html" press/feed.xml; then
+  ed -s press/feed.xml <<END
+/<\/channel>/i
+  <item>
+    <title>${N} - ${HEAD}</title>
+    <link>${CANON}</link>
+    <pubDate>$(date -R)</pubDate>
+    <description>New press release.</description>
+    <guid>${N}</guid>
+  </item>
+.
+w
+q
+END
+fi

--- a/site.css
+++ b/site.css
@@ -7,6 +7,7 @@ a{color:var(--accent);text-decoration:none}a:hover{text-decoration:underline}
 .card{border:1px solid var(--line);border-radius:10px;padding:14px;background:#141417}
 .foot{margin-top:36px;border-top:1px solid var(--line);color:var(--muted)}
 .cta a{display:inline-block;border:1px solid var(--line);padding:8px 12px;border-radius:8px}
-a:focus,button:focus{outline:2px solid #62d0ff;outline-offset:2px}
-.skip{position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden}
-.skip:focus{left:0;top:0;padding:8px;background:#000;color:#fff;z-index:100}
+:focus-visible{outline:2px solid #62d0ff;outline-offset:2px}
+.skip{position:absolute;left:-9999px}
+.skip:focus{left:8px;top:8px;background:#000;color:#fff;padding:8px;border-radius:6px}
+@media (prefers-reduced-motion: reduce){*{scroll-behavior:auto;animation:none;transition:none}}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,4 +6,9 @@
   <url><loc>https://no-gas-labs.github.io/nogaslabs-site/press/001-mirrors-edge.html</loc></url>
   <url><loc>https://no-gas-labs.github.io/nogaslabs-site/relics/</loc></url>
   <url><loc>https://no-gas-labs.github.io/nogaslabs-site/campaign/</loc></url>
+  <url><loc>https://no-gas-labs.github.io/nogaslabs-site/press/kit.html</loc></url>
+  <url><loc>https://no-gas-labs.github.io/nogaslabs-site/press/feed.xml</loc></url>
+  <url><loc>https://no-gas-labs.github.io/nogaslabs-site/humans.txt</loc></url>
+  <url><loc>https://no-gas-labs.github.io/nogaslabs-site/.well-known/security.txt</loc></url>
+  <url><loc>https://no-gas-labs.github.io/nogaslabs-site/manifest.webmanifest</loc></url>
 </urlset>


### PR DESCRIPTION
## Summary
- add focus-visible and reduced motion styles
- include skip link, canonical, robots, manifest, and RSS metadata
- refresh press kit with assets section and placeholder SVGs
- improve 404 page and add security/humans files
- add manifest, template and helper script for press posts
- expand sitemap and documentation

## Testing
- `html5validator --root . --also-check-css --blacklist ".git,.github"`

------
https://chatgpt.com/codex/tasks/task_e_688870983cac8322a592bef24b53e236