### PR TITLE
docs: add Mirror Force dev tasks to backlog

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,34 +1,17 @@
 # Backlog
 
 ## Short term
-- Task 1
-- Task 2
-- Task 3
-- Task 4
-- Task 5
-- Task 6
-- Task 7
-- Task 8
-- Task 9
-- Task 10
-- Task 11
-- Task 12
-- Task 13
+- Integrate Mirror Force into Telegram Bot
+- Develop Core Game Engine for Meme Physics
+- Deploy Smart Contracts for Mirror NFT & Reward Tokens
+- Integrate Blockchain Reward Logic in Game Outcomes
+- Perform QA, Unit Tests, Testnet Minting
 
 ## Mid term
-- Task 14
-- Task 15
-- Task 16
-- Task 17
-- Task 18
-- Task 19
-- Task 20
-- Task 21
-- Task 22
-- Task 23
-- Task 24
-- Task 25
-- Task 26
+- Add Real-Time Meme Events and Split-Physics Transitions
+- Add Analytics and Logging Hooks
+- Implement Referral Code Tracking and Rewards
+- Launch Tournament System + Leaderboards
 
 ## Long term
 - Task 27

--- a/TASKS_LOG.md
+++ b/TASKS_LOG.md
@@ -9,5 +9,8 @@
 3. [SiteKeeper -> Production/Build] Added robots and OG meta tags across pages, implemented aria-current script, and updated campaign copy.
    Files: 404.html, campaign/index.html, relics/index.html, press/index.html, press/kit.html, press/001-mirrors-edge.html, press/002-new-agenda.html, site.js, STATUS.md, TASKS_LOG.md
    Result: PASS
+4. [SiteKeeper -> Strategy/Plan] Added Mirror Force development tasks to backlog.
+   Files: BACKLOG.md, TASKS_LOG.md
+   Result: PASS
 2025-07-29T15:00:24Z  |  #1  |  bootstrap SYNC-LINK v1
 2025-07-29T15:01:19Z  |  #2  |  add dev dashboard


### PR DESCRIPTION
## Summary
- add Mirror Force development tasks to backlog
- log backlog update in tasks log

## Testing
- `scripts/link-check.sh .`


------
https://chatgpt.com/codex/tasks/task_e_688e5a85d47c83229a35b9f1d6ec7396